### PR TITLE
create_function() is deprecated

### DIFF
--- a/views_bulk_operations_plugin_style.inc
+++ b/views_bulk_operations_plugin_style.inc
@@ -337,7 +337,9 @@ class views_bulk_operations_plugin_style extends views_plugin_style_table {
       );
     }
 
-    uasort($operations, create_function('$a, $b', 'return strcasecmp($a["label"], $b["label"]);'));
+    uasort($operations, function($a, $b) {
+      return strcasecmp($a["label"], $b["label"]);
+    });
     $this->all_operations = $operations;
   }
 


### PR DESCRIPTION
FIX: Deprecated: Function create_function() is deprecated in views_bulk_operations_plugin_style->populate_operations()